### PR TITLE
Make tox grenade belt craftable at machining table

### DIFF
--- a/1.5/Patches/Biotech.xml
+++ b/1.5/Patches/Biotech.xml
@@ -59,7 +59,7 @@
 			<Crafting>7</Crafting>
 		</skillRequirements>
 		<recipeUsers>
-				<li>FabricationBench</li>
+				<li>TableMachining</li>
 		</recipeUsers>
       <useIngredientsForColor>false</useIngredientsForColor>
       <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
@@ -185,7 +185,7 @@
 			<Crafting>7</Crafting>
 		</skillRequirements>
 		<recipeUsers>
-				<li>FabricationBench</li>
+				<li>TableMachining</li>
 		</recipeUsers>
       <useIngredientsForColor>false</useIngredientsForColor>
       <workSpeedStat>GeneralLaborSpeed</workSpeedStat>


### PR DESCRIPTION
Currently, tox grenade belt can be crafted at a fabrication table. However, both tox grenades themselves and every single grenade in the mod is made at a machining table, making the tox grenades unnecessarily harder to create.

I'm assuming this was not intended and an oversight.